### PR TITLE
Operate on a range if provided

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -7,16 +7,17 @@ A Vim plugin to remove excessive whitespace from files.
 * Removes whitespace at the end of lines.
 * Removes sequential whitespace between words.
 * Ignores whitespace at the beginning of a line (to preserve indents).
+* Operates on the entire buffer by default, or a range if provided.
 
 # Options
 
-* WhiteWash\_Aggressive - Causes aggressive behavior by default. If enabled, removes sequential whitespace anywhere but the beginning of a line.
+* `WhiteWash_Aggressive` - Causes aggressive behavior by default. If enabled, removes sequential whitespace anywhere but the beginning of a line.
 ```vim
 let g:WhiteWash_Aggressive = 1
 ```
 
-# Functions
+# Commands
 
-* `:WhiteWash` - Strips trailing ^M's, trailing whitespace, and calls WhiteWashLazy or WhiteWashAggressive based on user preferences.
-* `:WhiteWashLazy` - Removes sequential whitespace between word characters, but not between punctuation.
+* `:WhiteWash` - Strips trailing whitespace, and calls `WhiteWashFriendly` or `WhiteWashAggressive` based on user preferences.
 * `:WhiteWashAggressive` - Removes sequential whitespace anywhere but the beginning of a line.
+* `:WhiteWashFriendly` - Removes sequential whitespace between word characters, but not between punctuation.

--- a/plugin/WhiteWash.vim
+++ b/plugin/WhiteWash.vim
@@ -2,44 +2,44 @@
 " Remove trailing whitespace and sequential whitespace between words.
 
 " Maintainer: Michael O'Neill <irish.dot@gmail.com>
-" Version:    2014.09.08
+" Version:    1.0.1
 " GetLatestVimScripts: 3920 1 :AutoInstall: WhiteWash.vim
 
-function! s:WhiteWash()
+function! s:white_wash()
 	" Save cursor position
 	let l:save_cursor = getpos(".")
 
 	" Remove trailing whitespace, quietly.
-	call s:WhiteWashTrailing()
+	call s:remove_trailing_space()
 
 	" Remove sequential whitespace with one of two options.
 	if exists("g:WhiteWash_Aggressive") && (g:WhiteWash_Aggressive)
-		call s:WhiteWashAggressive()
+		call s:remove_sequential_space_aggressive()
 	else
-		call s:WhiteWashLazy()
+		call s:remove_sequential_space_friendly()
 	endif
 
 	" Restore cursor position
 	call setpos('.', l:save_cursor)
 endfunction
 
-function! s:WhiteWashTrailing()
+function! s:remove_trailing_space()
 	" Remove trailing whitespace, quietly.
-	%s/\s\+$//e
+	s/\s\+$//e
 endfunction
 
-function! s:WhiteWashLazy()
-	" Remove sequential whitespace between words, quietly.
-	%s/\>\s\{2,\}/ /eg
-endfunction
-
-function! s:WhiteWashAggressive()
+function! s:remove_sequential_space_aggressive()
 	" Remove all sequential whitespace following non-whitespace, quietly.
-	%s/\(\S\)\s\{2,\}/\1 /eg
+	s/\S\zs\s\{2,\}/ /eg
+endfunction
+
+function! s:remove_sequential_space_friendly()
+	" Remove sequential whitespace between words, quietly.
+	s/\>\s\{2,\}/ /eg
 endfunction
 
 " :Commands
-command! -range=% WhiteWash :silent call <SID>WhiteWash()
-command! -range=% WhiteWashAggressive :silent call <SID>WhiteWashAggressive()
-command! -range=% WhiteWashLazy :silent call <SID>WhiteWashLazy()
-command! -range=% WhiteWashTrailing :silent call <SID>WhiteWashTrailing()
+command! -range=% WhiteWash silent <line1>,<line2> call <SID>white_wash()
+command! -range=% WhiteWashAggressive silent <line1>,<line2> call <SID>remove_sequential_space_aggressive()
+command! -range=% WhiteWashFriendly silent <line1>,<line2> call <SID>remove_sequential_space_friendly()
+command! -range=% WhiteWashTrailing silent <line1>,<line2> call <SID>remove_trailing_space()


### PR DESCRIPTION
- Pass the command range rather than operating on the entire buffer at
  all times. The default range is still the entire buffer, however.
- Change `WhiteWashLazy` to `WhiteWashFriendly` as "Friendly" provides
  better contrast to "Aggressive."
- Rename internal functions to be more descriptive and decouple from
  command names.
- Use the zero-width match meta-character (`\zs`) in
  `remove_sequential_space_aggressive` (formerly `WhiteWashAggressive`)
  to avoid actually rewriting non-whitespace content.
- Add new commands and features to the `README`.
- Change version scheme to not use the date.
- Resolves #1.