### PR TITLE
Add feature: add spaces after commas

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -1,4 +1,4 @@
-A Vim plugin to remove excessive whitespace from files.
+A Vim plugin to add and remove whitespace from files for cleaner reading.
 
 [Mirror](http://www.vim.org/scripts/script.php?script_id=3920)
 
@@ -8,6 +8,9 @@ A Vim plugin to remove excessive whitespace from files.
 * Removes sequential whitespace between words.
 * Ignores whitespace at the beginning of a line (to preserve indents).
 * Operates on the entire buffer by default, or a range if provided.
+* Adds spaces after commas in non-numeric strings.
+	* Changes `foo(bar,baz,boo)` to `foo(bar, baz, boo)`.
+	* Ignores large numbers (e.g. `1,234,456,789`), but not `foo(0,1)`.
 
 # Options
 
@@ -16,8 +19,14 @@ A Vim plugin to remove excessive whitespace from files.
 let g:WhiteWash_Aggressive = 1
 ```
 
+* `WhiteWash_Commas` - Add spaces after commas by default.
+```vim
+let g:WhiteWash_Commas = 1
+```
+
 # Commands
 
-* `:WhiteWash` - Strips trailing whitespace, and calls `WhiteWashFriendly` or `WhiteWashAggressive` based on user preferences.
+* `:WhiteWash` - Strips trailing whitespace, and performs other whitespace cleaning operations based on user preference.
 * `:WhiteWashAggressive` - Removes sequential whitespace anywhere but the beginning of a line.
 * `:WhiteWashFriendly` - Removes sequential whitespace between word characters, but not between punctuation.
+* `:WhiteWashCommas` - Adds a space after commas in strings which don't look like large numbers.

--- a/plugin/WhiteWash.vim
+++ b/plugin/WhiteWash.vim
@@ -2,7 +2,7 @@
 " Remove trailing whitespace and sequential whitespace between words.
 
 " Maintainer: Michael O'Neill <irish.dot@gmail.com>
-" Version:    1.0.1
+" Version:    1.1.0
 " GetLatestVimScripts: 3920 1 :AutoInstall: WhiteWash.vim
 
 function! s:white_wash()
@@ -17,6 +17,11 @@ function! s:white_wash()
 		call s:remove_sequential_space_aggressive()
 	else
 		call s:remove_sequential_space_friendly()
+	endif
+
+	" Optionally add commas after spaces
+	if exists("g:WhtieWash_Commas") && (g:WhiteWash_Commas)
+		call s:add_space_after_commas()
 	endif
 
 	" Restore cursor position
@@ -38,8 +43,15 @@ function! s:remove_sequential_space_friendly()
 	s/\>\s\{2,\}/ /eg
 endfunction
 
+function! s:add_space_after_commas()
+	" Add a space after commas which do not appear to be part of a large
+	" number (e.g. 1,234,567,890), quietly.
+	s/\S,\zs\ze\(\d\{3\}\|\s\|\\\)\@!/ /eg
+endfunction
+
 " :Commands
 command! -range=% WhiteWash silent <line1>,<line2> call <SID>white_wash()
 command! -range=% WhiteWashAggressive silent <line1>,<line2> call <SID>remove_sequential_space_aggressive()
 command! -range=% WhiteWashFriendly silent <line1>,<line2> call <SID>remove_sequential_space_friendly()
 command! -range=% WhiteWashTrailing silent <line1>,<line2> call <SID>remove_trailing_space()
+command! -range=% WhiteWashCommas silent <line1>,<line2> call <SID>add_space_after_commas()


### PR DESCRIPTION
- Add `:WhiteWashCommas` command to add spaces after commas. This should
  not affect large numbers using commas as separators, and similarly
  ignores commas followed immediately by a backslash (`\`).
- Update the `README` to include information about the `WhiteWash_Commas`
  option and `:WhiteWashCommas` command.
- Resolves #2.