### PR TITLE
Rewrite the interface, add help, fix commas

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -1,4 +1,5 @@
-A Vim plugin to add and remove whitespace from files for cleaner reading.
+A Vim plugin to add and remove whitespace from files for opinionated tidiness
+and (hopefully) enhanced readability.
 
 [Mirror](http://www.vim.org/scripts/script.php?script_id=3920)
 
@@ -6,27 +7,35 @@ A Vim plugin to add and remove whitespace from files for cleaner reading.
 
 * Removes whitespace at the end of lines.
 * Removes sequential whitespace between words.
-* Ignores whitespace at the beginning of a line (to preserve indents).
-* Operates on the entire buffer by default, or a range if provided.
+	* Ignores whitespace at the beginning of a line (to preserve indents).
 * Adds spaces after commas in non-numeric strings.
 	* Changes `foo(bar,baz,boo)` to `foo(bar, baz, boo)`.
 	* Ignores large numbers (e.g. `1,234,456,789`), but not `foo(0,1)`.
+* Operates on the entire buffer by default, or a range if provided.
+* Aggressive mode for when you know better than the safeguards.
 
 # Options
 
-* `WhiteWash_Aggressive` - Causes aggressive behavior by default. If enabled, removes sequential whitespace anywhere but the beginning of a line.
+* `g:WhiteWash.auto` - Enabled rules are run whenever `:WhiteWash` is called.
 ```vim
-let g:WhiteWash_Aggressive = 1
+" Set to 0 to disable a rule
+let g:WhiteWash.auto.commas = 0
+let g:WhiteWash.auto.sequential = 0
+let g:WhiteWash.auto.trailing = 0
 ```
 
-* `WhiteWash_Commas` - Add spaces after commas by default.
+* `g:WhiteWash.aggressive` - Define which rules should run with aggressive mode
+  by default.
 ```vim
-let g:WhiteWash_Commas = 1
+let g:WhiteWash.aggressive.commas = 1
+let g:WhiteWash.aggressive.sequential = 1
 ```
 
 # Commands
 
-* `:WhiteWash` - Strips trailing whitespace, and performs other whitespace cleaning operations based on user preference.
-* `:WhiteWashAggressive` - Removes sequential whitespace anywhere but the beginning of a line.
-* `:WhiteWashFriendly` - Removes sequential whitespace between word characters, but not between punctuation.
-* `:WhiteWashCommas` - Adds a space after commas in strings which don't look like large numbers.
+* `:WhiteWash` - Run all enabled WhiteWash rules.
+* `:WhiteWashAggressive` - Run all enabled WhiteWash rules in aggressive mode.
+* `:WhiteWashCommas` - Run only the commas rule (respects aggressive setting).
+* `:WhiteWashSequential` - Run only the sequential rule (respects aggressive
+  setting).
+* `:WhiteWashTrailing` - Remove trailing whitespace.

--- a/doc/WhiteWash.txt
+++ b/doc/WhiteWash.txt
@@ -14,26 +14,74 @@ FEATURES                                                          *whitewash*
 ==============================================================================
 RULES                                                       *whitewash-rules*
 
+WhiteWash can perform several different operations when invoked, each of which
+can be enabled or disabled, and some of which have an "aggressive" mode.
+See |whitewash-examples| for more.
+
+                                                   *whitewash-rules-trailing*
+1. Trailing - All whitespace at the end of a line is removed.
+                                                 *whitewash-rules-sequential*
+2. Sequential - Consecutive whitespace characters between words is reduced to
+   a single space character. In aggressive mode, this also collapses tabs and
+   spaces used for alignment after punctuation. This rule never modifies
+   leading whitespace so as not to disturb indentation.
+                                                     *whitewash-rules-commas*
+3. Commas - A single space is added after commas. Some effort is made to not
+   disrupt numbers using commas as a digit separator, count modifiers to
+   regular expressions, etc., but exercise caution when using this on the
+   whole buffer. In aggressive mode, a single space is added after every comma
+   which is missing one, regardless of its context.
+
 ==============================================================================
 EXAMPLES                                                 *whitewash-examples*
+
+It may be useful to `:set list` in order to see all changes. Changed and
+unchanged lines are prefixed with a + and - respectively.
+
+Before~
+* Trailing whitespace.        
+* foo(bar,baz,rab)
+* 123,456,789
+* Some  keyboards  have    a  really  sensitive space   bar.    Also this.
+* Version:        2.0.0 (Spaces)
+* Version:	2.0.0 (Tab)
+* s/\S\zs\s\{2,\}/ /eg
+
+After WhiteWash~
++ Trailing whitespace.
++ foo(bar, baz, rab)
+- 123,456,789
++ Some keyboards have a really sensitive space bar.    Also this.
+- Version:        2.0.0 (Spaces)
+- Version:	2.0.0 (Tab)
+- s/\S\zs\s\{2,\}/ /eg
+
+After WhiteWashAggressive~
++ Trailing whitespace.
++ foo(bar, baz, rab)
++ 123, 456, 789
++ Some keyboards have a really sensitive space bar. Also this.
++ Version: 2.0.0 (Spaces)
+- Version:	2.0.0 (Tab)
++ s/\S\zs\s\{2, \}/ /eg
 
 ==============================================================================
 COMMANDS                                                 *whitewash-commands*
 
+All commands accept a [range]. If a [range] is not given, the command will act
+on the entire buffer.
+
 								  *:WhiteWash*
 :[range]WhiteWash	Run all |WhiteWash| rules enabled in |WhiteWash.auto|.
 			By default, all rules are enabled, but the aggressive
-			mode is not. If a [range] is not given, act on the
-			entire buffer.
+			mode is not.
 
 :[range]WhiteWashAggressive         *:WhiteWashAggressive* *WhiteWashAggressive*
 			Run all |WhiteWash| rules enabled in |WhiteWash.auto|
 			as if their |WhiteWash.aggressive| setting were
-			enabled. If a [range] is not given, act on the entire
-			buffer. Aggressive mode can be made the default on a
-			per-rule basis. >
- let g:WhiteWash.aggressive.<rule> = 1
-<
+			enabled. Aggressive mode can be made the default on a
+			per-rule basis.
+
                                             *:WhiteWashCommas* *WhiteWashCommas*
 :[range]WhiteWashCommas Run the "commas" rule, which will add a single space
 			after every comma which is not already followed by
@@ -43,33 +91,42 @@ COMMANDS                                                 *whitewash-commands*
 			changed, but 12,34,56 will). In aggressive mode, add a
 			space after every comma not already followed by space,
 			regardless of what the rest of the string looks like.
-			If a [range] is not given, act on the entire buffer.
-			This rule is enabled default and will be run whenever
-			|:WhiteWash| is called.
+
 			Note Be very careful using this around regular
 			expressions or other parsing code, especially in
 			aggressive mode.
->
- let g:WhiteWash.auto.commas = 0       " Do not run this rule by default
- let g:WhiteWash.aggressive.commas = 1 " Enable aggressive mode by default
-<
+
 :[range]WhiteWashSequential         *:WhiteWashSequential* *WhiteWashSequential*
 			Run the "sequential" rule, which will remove
 			sequential spaces between words. This includes things
 			like two spaces after a period, but excludes things
 			like leading tabs so as not to destroy indenting.
->
- let g:WhiteWash.auto.sequential = 0       " Do not run this rule by default
- let g:WhiteWash.aggressive.sequential = 1 " Enable aggressive mode by default
-<
-:[range]WhiteWashTrailing               *:WhiteWashTrailing* *WhiteWashTrailing*
 
+:[range]WhiteWashTrailing               *:WhiteWashTrailing* *WhiteWashTrailing*
+			Run the "trailing" rule, which will remove all
+			whitespace after the last non-whitespace character
+			until the end of the line.
 
 ==============================================================================
 OPTIONS                                  *WhiteWash-options* *whitewash-options*
 
 WhiteWash.auto                                                *WhiteWash.auto*
-
-WhiteWash.aggressive                                    *WhiteWash.aggressive*
-
+Set which rules to run when calling |:WhiteWash|. A value of 0 is considered
+disabled, all other values are considered enabled. All rules are enabled by
+default.
+>
+ " Set to 0 to disable a rule
+ let g:WhiteWash.auto.commas = 0
+ let g:WhiteWash.auto.sequential = 0
+ let g:WhiteWash.auto.trailing = 0
+<
+g:WhiteWash.aggressive                                  *WhiteWash.aggressive*
+Set whether the aggressive mode should be used by default on a per rule basis.
+0 is considered disabled, all other values are considered enabled. Aggressive
+mode is disabled by default.
+>
+ " Set to a non-zero value to enable aggressive mode
+ let g:WhiteWash.aggressive.commas = 1
+ let g:WhiteWash.aggressive.sequential = 1
+<
  vim:tw=78:ts=8:ft=help:norl:

--- a/doc/WhiteWash.txt
+++ b/doc/WhiteWash.txt
@@ -4,7 +4,7 @@ Author:  Michael "Irish" O'Neill
 License: Same terms as Vim itself (see |license|)
 
 ==============================================================================
-FEATURES                                                 *WhiteWash* *whitewash*
+FEATURES                                                          *whitewash*
 
 * Remove trailing whitespace. |WhiteWashTrailing|
 * Remove sequential whitespace. |WhiteWashSequential|
@@ -12,7 +12,13 @@ FEATURES                                                 *WhiteWash* *whitewash*
 * Optional aggressive mode. |WhiteWashAggressive|
 
 ==============================================================================
-COMMANDS                               *WhiteWash-commands* *whitewash-commands*
+RULES                                                       *whitewash-rules*
+
+==============================================================================
+EXAMPLES                                                 *whitewash-examples*
+
+==============================================================================
+COMMANDS                                                 *whitewash-commands*
 
 								  *:WhiteWash*
 :[range]WhiteWash	Run all |WhiteWash| rules enabled in |WhiteWash.auto|.
@@ -65,3 +71,5 @@ OPTIONS                                  *WhiteWash-options* *whitewash-options*
 WhiteWash.auto                                                *WhiteWash.auto*
 
 WhiteWash.aggressive                                    *WhiteWash.aggressive*
+
+ vim:tw=78:ts=8:ft=help:norl:

--- a/doc/WhiteWash.txt
+++ b/doc/WhiteWash.txt
@@ -85,27 +85,26 @@ on the entire buffer.
                                             *:WhiteWashCommas* *WhiteWashCommas*
 :[range]WhiteWashCommas Run the "commas" rule, which will add a single space
 			after every comma which is not already followed by
-			whitespace. By default, effort is made to avoid adding
-			spaces to anything that looks like a number using
-			commas for digit grouping (e.g. 123,456 will not be
-			changed, but 12,34,56 will). In aggressive mode, add a
-			space after every comma not already followed by space,
-			regardless of what the rest of the string looks like.
+			whitespace.
 
-			Note Be very careful using this around regular
+			Note: Be very careful using this around regular
 			expressions or other parsing code, especially in
 			aggressive mode.
 
+			See |whitewash-rules-commas| for more.
+
 :[range]WhiteWashSequential         *:WhiteWashSequential* *WhiteWashSequential*
 			Run the "sequential" rule, which will remove
-			sequential spaces between words. This includes things
-			like two spaces after a period, but excludes things
-			like leading tabs so as not to destroy indenting.
+			sequential spaces between words.
+
+			See |whitewash-rules-sequential| for more.
 
 :[range]WhiteWashTrailing               *:WhiteWashTrailing* *WhiteWashTrailing*
 			Run the "trailing" rule, which will remove all
 			whitespace after the last non-whitespace character
 			until the end of the line.
+
+			See |whitewash-rules-trailing| for more.
 
 ==============================================================================
 OPTIONS                                  *WhiteWash-options* *whitewash-options*

--- a/doc/WhiteWash.txt
+++ b/doc/WhiteWash.txt
@@ -1,0 +1,67 @@
+*WhiteWash.txt* Add and remove whitespace with strong opinions.
+
+Author:  Michael "Irish" O'Neill
+License: Same terms as Vim itself (see |license|)
+
+==============================================================================
+FEATURES                                                 *WhiteWash* *whitewash*
+
+* Remove trailing whitespace. |WhiteWashTrailing|
+* Remove sequential whitespace. |WhiteWashSequential|
+* Add spaces after commas. |WhiteWashCommas|
+* Optional aggressive mode. |WhiteWashAggressive|
+
+==============================================================================
+COMMANDS                               *WhiteWash-commands* *whitewash-commands*
+
+								  *:WhiteWash*
+:[range]WhiteWash	Run all |WhiteWash| rules enabled in |WhiteWash.auto|.
+			By default, all rules are enabled, but the aggressive
+			mode is not. If a [range] is not given, act on the
+			entire buffer.
+
+:[range]WhiteWashAggressive         *:WhiteWashAggressive* *WhiteWashAggressive*
+			Run all |WhiteWash| rules enabled in |WhiteWash.auto|
+			as if their |WhiteWash.aggressive| setting were
+			enabled. If a [range] is not given, act on the entire
+			buffer. Aggressive mode can be made the default on a
+			per-rule basis. >
+ let g:WhiteWash.aggressive.<rule> = 1
+<
+                                            *:WhiteWashCommas* *WhiteWashCommas*
+:[range]WhiteWashCommas Run the "commas" rule, which will add a single space
+			after every comma which is not already followed by
+			whitespace. By default, effort is made to avoid adding
+			spaces to anything that looks like a number using
+			commas for digit grouping (e.g. 123,456 will not be
+			changed, but 12,34,56 will). In aggressive mode, add a
+			space after every comma not already followed by space,
+			regardless of what the rest of the string looks like.
+			If a [range] is not given, act on the entire buffer.
+			This rule is enabled default and will be run whenever
+			|:WhiteWash| is called.
+			Note Be very careful using this around regular
+			expressions or other parsing code, especially in
+			aggressive mode.
+>
+ let g:WhiteWash.auto.commas = 0       " Do not run this rule by default
+ let g:WhiteWash.aggressive.commas = 1 " Enable aggressive mode by default
+<
+:[range]WhiteWashSequential         *:WhiteWashSequential* *WhiteWashSequential*
+			Run the "sequential" rule, which will remove
+			sequential spaces between words. This includes things
+			like two spaces after a period, but excludes things
+			like leading tabs so as not to destroy indenting.
+>
+ let g:WhiteWash.auto.sequential = 0       " Do not run this rule by default
+ let g:WhiteWash.aggressive.sequential = 1 " Enable aggressive mode by default
+<
+:[range]WhiteWashTrailing               *:WhiteWashTrailing* *WhiteWashTrailing*
+
+
+==============================================================================
+OPTIONS                                  *WhiteWash-options* *whitewash-options*
+
+WhiteWash.auto                                                *WhiteWash.auto*
+
+WhiteWash.aggressive                                    *WhiteWash.aggressive*

--- a/plugin/WhiteWash.vim
+++ b/plugin/WhiteWash.vim
@@ -68,8 +68,8 @@ function! s:add_space_after_commas(aggressive)
 endfunction
 
 " :Commands
-command! -range=% WhiteWash <line1>,<line2> call <SID>white_wash(v:null)
-command! -range=% WhiteWashAggressive <line1>,<line2> call <SID>white_wash(1)
-command! -range=% WhiteWashCommas <line1>,<line2> call <SID>add_space_after_commas(g:WhiteWash.aggressive.commas)
-command! -range=% WhiteWashSequential <line1>,<line2> call <SID>remove_sequential_space(g:WhiteWash.aggressive.sequential)
+command! -range=% -nargs=? WhiteWash <line1>,<line2> call <SID>white_wash(v:null)
+command! -range=% -nargs=? WhiteWashAggressive <line1>,<line2> call <SID>white_wash(1)
+command! -range=% -nargs=? WhiteWashCommas <line1>,<line2> call <SID>add_space_after_commas(g:WhiteWash.aggressive.commas)
+command! -range=% -nargs=? WhiteWashSequential <line1>,<line2> call <SID>remove_sequential_space(g:WhiteWash.aggressive.sequential)
 command! -range=% WhiteWashTrailing <line1>,<line2> call <SID>remove_trailing_space()

--- a/plugin/WhiteWash.vim
+++ b/plugin/WhiteWash.vim
@@ -60,7 +60,7 @@ function! s:add_space_after_commas(aggressive)
 	if a:aggressive == 0
 		" Add a space after commas which do not appear to be part of a large
 		" number (e.g. 1,234,567,890), quietly.
-		s/\S,\zs\ze\(\(\d\d\d\(\D\|$\)\)\|\\\)\@!\S/ /eg
+		s/\S,\zs\ze\(\(\d\d\d\(\D\|$\)\)\|\\\|[{}]\)\@!\S/ /eg
 	else
 		" Add a space after all cramped commas, quietly.
 		s/\S,\zs\ze\S/ /eg

--- a/plugin/WhiteWash.vim
+++ b/plugin/WhiteWash.vim
@@ -2,26 +2,39 @@
 " Remove trailing whitespace and sequential whitespace between words.
 
 " Maintainer: Michael O'Neill <irish.dot@gmail.com>
-" Version:    1.1.0
+" Version:    2.0.0
 " GetLatestVimScripts: 3920 1 :AutoInstall: WhiteWash.vim
 
-function! s:white_wash()
+" Set default options
+let g:WhiteWash = {
+	\ 'auto': {
+		\ 'commas': 1,
+		\ 'sequential': 1,
+		\ 'trailing': 1,
+	\ },
+	\ 'aggressive': {
+		\ 'commas': 0,
+		\ 'sequential': 0,
+	\ },
+\ }
+
+function! s:white_wash(aggressive)
 	" Save cursor position
-	let l:save_cursor = getpos(".")
+	let l:save_cursor = getpos('.')
 
-	" Remove trailing whitespace, quietly.
-	call s:remove_trailing_space()
-
-	" Remove sequential whitespace with one of two options.
-	if exists("g:WhiteWash_Aggressive") && (g:WhiteWash_Aggressive)
-		call s:remove_sequential_space_aggressive()
-	else
-		call s:remove_sequential_space_friendly()
+	if g:WhiteWash.auto.trailing
+		" Remove trailing whitespace if enabled
+		call s:remove_trailing_space()
 	endif
 
-	" Optionally add commas after spaces
-	if exists("g:WhtieWash_Commas") && (g:WhiteWash_Commas)
-		call s:add_space_after_commas()
+	if g:WhiteWash.auto.sequential
+		" Remove sequential whitespace if enabled
+		call s:remove_sequential_space(g:WhiteWash.aggressive.sequential || a:aggressive)
+	endif
+
+	if g:WhiteWash.auto.commas
+		" Add space after commas if enabled
+		call s:add_space_after_commas(g:WhiteWash.aggressive.commas || a:aggressive)
 	endif
 
 	" Restore cursor position
@@ -33,25 +46,30 @@ function! s:remove_trailing_space()
 	s/\s\+$//e
 endfunction
 
-function! s:remove_sequential_space_aggressive()
-	" Remove all sequential whitespace following non-whitespace, quietly.
-	s/\S\zs\s\{2,\}/ /eg
+function! s:remove_sequential_space(aggressive)
+	if a:aggressive == 0
+		" Remove sequential whitespace between words, quietly.
+		s/\>\s\{2,\}/ /eg
+	else
+		" Remove all sequential whitespace following non-whitespace, quietly.
+		s/\S\zs\s\{2,\}/ /eg
+	endif
 endfunction
 
-function! s:remove_sequential_space_friendly()
-	" Remove sequential whitespace between words, quietly.
-	s/\>\s\{2,\}/ /eg
-endfunction
-
-function! s:add_space_after_commas()
-	" Add a space after commas which do not appear to be part of a large
-	" number (e.g. 1,234,567,890), quietly.
-	s/\S,\zs\ze\(\d\{3\}\|\s\|\\\)\@!/ /eg
+function! s:add_space_after_commas(aggressive)
+	if a:aggressive == 0
+		" Add a space after commas which do not appear to be part of a large
+		" number (e.g. 1,234,567,890), quietly.
+		s/\S,\zs\ze\(\(\d\d\d\(\D\|$\)\)\|\\\)\@!\S/ /eg
+	else
+		" Add a space after all cramped commas, quietly.
+		s/\S,\zs\ze\S/ /eg
+	endif
 endfunction
 
 " :Commands
-command! -range=% WhiteWash silent <line1>,<line2> call <SID>white_wash()
-command! -range=% WhiteWashAggressive silent <line1>,<line2> call <SID>remove_sequential_space_aggressive()
-command! -range=% WhiteWashFriendly silent <line1>,<line2> call <SID>remove_sequential_space_friendly()
-command! -range=% WhiteWashTrailing silent <line1>,<line2> call <SID>remove_trailing_space()
-command! -range=% WhiteWashCommas silent <line1>,<line2> call <SID>add_space_after_commas()
+command! -range=% WhiteWash <line1>,<line2> call <SID>white_wash(v:null)
+command! -range=% WhiteWashAggressive <line1>,<line2> call <SID>white_wash(1)
+command! -range=% WhiteWashCommas <line1>,<line2> call <SID>add_space_after_commas(g:WhiteWash.aggressive.commas)
+command! -range=% WhiteWashSequential <line1>,<line2> call <SID>remove_sequential_space(g:WhiteWash.aggressive.sequential)
+command! -range=% WhiteWashTrailing <line1>,<line2> call <SID>remove_trailing_space()


### PR DESCRIPTION
- Implement options in a more sane and modular way. Allow each rule to
  have its auto-run and aggressive mode toggled. Enable all rules and no
  aggressive modes by default.
- Add a `:command` for each rule, and allow the `:WhiteWashAggressive`
  command to overwrite all aggressive options at once.
- Add documentation.
- Rewrite the non-aggressive `add_space_after_commas` regex.
- Bump version number.
- Resolve #5.
- Resolve #6.